### PR TITLE
add FinalSync to sync nb and lb, push to run dashboard

### DIFF
--- a/assets/email_run_finish.groovy
+++ b/assets/email_run_finish.groovy
@@ -43,7 +43,7 @@ html(lang:'en') {
             h3 "Folder: ${run.analysis_dir}"
             p {
                 span "Run processing finished. Full report attached to this email, but also available "
-                a ( href:"https://datahub-297-p25.p.genap.ca/Freezeman_validation/${event.year}/${run.run}.report.html", "on GenAP" )
+                a ( href:"https://datahub-297-p25.p.genap.ca/Freezeman_validation/${event.year}/${event.data.run_name}.report.html", "on GenAP" )
                 span "."
             }
             ul {

--- a/workflows/freezeman/monitor.nf
+++ b/workflows/freezeman/monitor.nf
@@ -46,7 +46,7 @@ process RunMultiQC {
     executor 'local'
     errorStrategy = 'ignore'
     maxForks 1
-    module 'mugqic_dev/MultiQC_C3G/1.23_64e8b8a'
+    module 'mugqic_dev/MultiQC_C3G/1.23_dda3293'
 
     input:
     tuple path(rundir), path(donefile)

--- a/workflows/freezeman/monitor.nf
+++ b/workflows/freezeman/monitor.nf
@@ -78,9 +78,6 @@ process FinalSync {
     """
     rundir=\$( echo $run_dir | sed 's/\\[//' | sed 's/\\]//' )
     rsync -av /nb/Research/freezeman-processing/${multiqc.seqtype}/*/\${rundir}/report/multiqc_* /lb/robot/research/freezeman-processing/${multiqc.seqtype}/*/\${rundir}/report
-    curl -k -X POST https://dashrunr.c3g-app.sd4h.ca/update \\
-        -H "descrambler-key: \$(cat ~/assets/run-processing-update-headers)" \\
-        -H "Content-Type: application/json" -d @/nb/Research/freezeman-processing/${multiqc.seqtype}/*/\${rundir}/report/multiqc_data/multiqc_data.json
     """
 }
 

--- a/workflows/freezeman/monitor.nf
+++ b/workflows/freezeman/monitor.nf
@@ -63,6 +63,22 @@ process RunMultiQC {
     """
 }
 
+process FinalSync {
+    executor 'local'
+    errorStrategy = 'ignore'
+    maxForks 1
+
+    input:
+    tuple path(rundir), path(donefile)
+
+    """
+    rsync -av $rundir/report/multiqc_* /lb/robot/research/freezeman-processing/*/*/$rundir/report
+    curl -k -X POST https://dashrunr.c3g-app.sd4h.ca/update \\
+        -H "descrambler-key: \$(cat ~/assets/run-processing-update-headers)" \\
+        -H "Content-Type: application/json" -d @$rundir/report/multiqc_data/multiqc_data.json
+    """
+}
+
 process GenapUpload {
     tag { multiqc.flowcell }
     executor 'local'
@@ -171,7 +187,7 @@ workflow WatchFinish {
     // Upload to GenAP + Send end-of-processing email notification
     donefiles
     | map { donefile -> [donefile.getParent().getParent().getParent(), donefile] }
-    | RunMultiQC
+    | (RunMultiQC & FinalSync)
     | map { html, json -> [html, new MultiQC(json)] }
     | (GenapUpload & EmailAlertFinish)
 }

--- a/workflows/freezeman/monitor.nf
+++ b/workflows/freezeman/monitor.nf
@@ -76,7 +76,7 @@ process FinalSync {
     def run_dir = multiqc.analysis_dir.toString()
 
     """
-    rundir=$( echo $run_dir | sed 's/\[//' | sed 's/\]//' )
+    rundir=\$( echo $run_dir | sed 's/\\[//' | sed 's/\\]//' )
     rsync -av /nb/Research/freezeman-processing/${multiqc.seqtype}/*/\${rundir}/report/multiqc_* /lb/robot/research/freezeman-processing/${multiqc.seqtype}/*/\${rundir}/report
     curl -k -X POST https://dashrunr.c3g-app.sd4h.ca/update \\
         -H "descrambler-key: \$(cat ~/assets/run-processing-update-headers)" \\

--- a/workflows/freezeman/monitor.nf
+++ b/workflows/freezeman/monitor.nf
@@ -64,7 +64,7 @@ process RunMultiQC {
 }
 
 process FinalSync {
-    tag { multiqc.flowcell }
+    tag { multiqc.run }
     executor 'local'
     errorStrategy = 'ignore'
     maxForks 1

--- a/workflows/freezeman/monitor.nf
+++ b/workflows/freezeman/monitor.nf
@@ -64,12 +64,13 @@ process RunMultiQC {
 }
 
 process FinalSync {
+    tag { multiqc.flowcell }
     executor 'local'
     errorStrategy = 'ignore'
     maxForks 1
 
     input:
-    tuple path(rundir), path(donefile)
+    tuple val(multiqc_html), val(multiqc), path(rundir)
 
     """
     rsync -av $rundir/report/multiqc_* /lb/robot/research/freezeman-processing/*/*/$rundir/report
@@ -187,7 +188,7 @@ workflow WatchFinish {
     // Upload to GenAP + Send end-of-processing email notification
     donefiles
     | map { donefile -> [donefile.getParent().getParent().getParent(), donefile] }
-    | (RunMultiQC & FinalSync)
-    | map { html, json -> [html, new MultiQC(json)] }
-    | (GenapUpload & EmailAlertFinish)
+    | RunMultiQC
+    | map { html, json -> [html, new MultiQC(json), html.getParent().getParent()] }
+    | (GenapUpload & EmailAlertFinish & FinalSync) 
 }

--- a/workflows/freezeman/monitor.nf
+++ b/workflows/freezeman/monitor.nf
@@ -70,13 +70,13 @@ process FinalSync {
     maxForks 1
 
     input:
-    tuple val(multiqc_html), val(multiqc), path(rundir)
+    tuple val(multiqc_html), val(multiqc) 
 
     """
-    rsync -av $rundir/report/multiqc_* /lb/robot/research/freezeman-processing/*/*/$rundir/report
+    rsync -av /nb/Research/freezeman-processing/${multiqc.seqtype}/*/${multiqc.analysis_dir}/report/multiqc_* /lb/robot/research/freezeman-processing/${multiqc.seqtype}/*/${multiqc.analysis_dir}/report
     curl -k -X POST https://dashrunr.c3g-app.sd4h.ca/update \\
         -H "descrambler-key: \$(cat ~/assets/run-processing-update-headers)" \\
-        -H "Content-Type: application/json" -d @$rundir/report/multiqc_data/multiqc_data.json
+        -H "Content-Type: application/json" -d @/nb/Research/freezeman-processing/${multiqc.seqtype}/*/${multiqc.analysis_dir}/report/multiqc_data/multiqc_data.json
     """
 }
 
@@ -189,6 +189,6 @@ workflow WatchFinish {
     donefiles
     | map { donefile -> [donefile.getParent().getParent().getParent(), donefile] }
     | RunMultiQC
-    | map { html, json -> [html, new MultiQC(json), html.getParent().getParent()] }
-    | (GenapUpload & EmailAlertFinish & FinalSync) 
+    | map { html, json -> [html, new MultiQC(json)] }
+    | (GenapUpload & EmailAlertFinish & FinalSync)
 }

--- a/workflows/freezeman/monitor.nf
+++ b/workflows/freezeman/monitor.nf
@@ -72,11 +72,15 @@ process FinalSync {
     input:
     tuple val(multiqc_html), val(multiqc) 
 
+    script:
+    def run_dir = multiqc.analysis_dir.toString()
+
     """
-    rsync -av /nb/Research/freezeman-processing/${multiqc.seqtype}/*/${multiqc.analysis_dir}/report/multiqc_* /lb/robot/research/freezeman-processing/${multiqc.seqtype}/*/${multiqc.analysis_dir}/report
+    rundir=$( echo $run_dir | sed 's/\[//' | sed 's/\]//' )
+    rsync -av /nb/Research/freezeman-processing/${multiqc.seqtype}/*/\${rundir}/report/multiqc_* /lb/robot/research/freezeman-processing/${multiqc.seqtype}/*/\${rundir}/report
     curl -k -X POST https://dashrunr.c3g-app.sd4h.ca/update \\
         -H "descrambler-key: \$(cat ~/assets/run-processing-update-headers)" \\
-        -H "Content-Type: application/json" -d @/nb/Research/freezeman-processing/${multiqc.seqtype}/*/${multiqc.analysis_dir}/report/multiqc_data/multiqc_data.json
+        -H "Content-Type: application/json" -d @/nb/Research/freezeman-processing/${multiqc.seqtype}/*/\${rundir}/report/multiqc_data/multiqc_data.json
     """
 }
 


### PR DESCRIPTION
attempt to add a final sync between /nb/Research and /lb/robot/ to resolve multiqc reports not being complete on /lb/robot/. Also pushes the final multiqc json to the run processing dashboard. Should run only after RunMultiQC has completed. 